### PR TITLE
Fix issue in decorator class exmaple in decorators.rst

### DIFF
--- a/decorators.rst
+++ b/decorators.rst
@@ -440,9 +440,9 @@ will not be covered here).
         A logit implementation for sending emails to admins
         when the function is called.
         '''
-        def __init__(self, email='admin@myproject.com', *args, **kwargs):
+        def __init__(self, func, email='admin@myproject.com'):
             self.email = email
-            super(email_logit, self).__init__(*args, **kwargs)
+            super(email_logit, self).__init__(func)
             
         def notify(self):
             # Send an email to self.email


### PR DESCRIPTION
Seems like passing variable arguments and key word arguments to the __init__() of the super class is incorrect